### PR TITLE
Fix HTTP2 Test scenario and forcefully kill Ballerina process

### DIFF
--- a/distribution/scripts/ballerina/ballerina-start.sh
+++ b/distribution/scripts/ballerina/ballerina-start.sh
@@ -77,6 +77,14 @@ fi
 if pgrep -f ballerina.*/bre >/dev/null; then
     echo "Shutting down Ballerina"
     pkill -f ballerina.*/bre
+    # Wait for few seconds
+    sleep 5
+fi
+
+# Check whether process exists
+if pgrep -f ballerina.*/bre >/dev/null; then
+    echo "Killing Ballerina process!!"
+    pkill -9 -f ballerina.*/bre
 fi
 
 if [ ! -d "${ballerina_path}/logs" ]; then

--- a/distribution/scripts/jmeter/run-performance-tests.sh
+++ b/distribution/scripts/jmeter/run-performance-tests.sh
@@ -144,7 +144,7 @@ function before_execute_test_scenario() {
     local protocol=${scenario[protocol]}
     jmeter_params+=("host=$ballerina_host" "port=9090" "path=$service_path")
     jmeter_params+=("payload=$HOME/${msize}B.json" "response_size=${msize}B" "protocol=$protocol")
-    JMETER_JVM_ARGS="-Xbootclasspath/p:$HOME/alpnboot.jar"
+    JMETER_JVM_ARGS="-Xbootclasspath/p:/opt/alpnboot/alpnboot.jar"
     echo "Starting Ballerina Service. Ballerina Program: $bal_file, Heap: $heap, Flags: ${bal_flags:-N/A}"
     ssh $ballerina_ssh_host "./ballerina/ballerina-start.sh -p $HOME/ballerina/bal -b $bal_file -m $heap -- $bal_flags"
 }

--- a/distribution/scripts/setup/setup-jmeter-ballerina.sh
+++ b/distribution/scripts/setup/setup-jmeter-ballerina.sh
@@ -29,6 +29,9 @@ fi
 export script_name="$0"
 script_dir=$(dirname "$0")
 
+alpnboot_dir="/opt/alpnboot"
+mkdir -p $alpnboot_dir
+
 $script_dir/setup-jmeter.sh "$@" -j bzm-http2 -j websocket-samplers \
     -w http://search.maven.org/remotecontent?filepath=org/mortbay/jetty/alpn/alpn-boot/8.1.12.v20180117/alpn-boot-8.1.12.v20180117.jar \
-    -o alpnboot.jar
+    -o $alpnboot_dir/alpnboot.jar

--- a/distribution/scripts/setup/setup-jmeter-client-ballerina.sh
+++ b/distribution/scripts/setup/setup-jmeter-client-ballerina.sh
@@ -29,6 +29,9 @@ fi
 export script_name="$0"
 script_dir=$(dirname "$0")
 
+alpnboot_dir="/opt/alpnboot"
+mkdir -p $alpnboot_dir
+
 $script_dir/setup-jmeter-client.sh "$@" -j bzm-http2 -j websocket-samplers \
     -w http://search.maven.org/remotecontent?filepath=org/mortbay/jetty/alpn/alpn-boot/8.1.12.v20180117/alpn-boot-8.1.12.v20180117.jar \
-    -o alpnboot.jar
+    -o $alpnboot_dir/alpnboot.jar


### PR DESCRIPTION
## Purpose
Fix HTTP2 Test scenario and forcefully kill Ballerina process

## Goals
* Fix alpnboot.jar path to fix HTTP2 test scenario
* Kill Ballerina process using -9 signal