### PR TITLE
Print cloudformation stack CREATE_FAILED events

### DIFF
--- a/cloudformation/run-performance-tests.sh
+++ b/cloudformation/run-performance-tests.sh
@@ -279,6 +279,13 @@ echo "$create_stack_command"
 stack_id="$($create_stack_command)"
 
 function exit_handler() {
+    # Get stack events
+    local stack_events_json=$results_dir/stack-events.json
+    echo "Saving stack events to $stack_events_json"
+    aws cloudformation describe-stack-events --stack-name $stack_id --no-paginate --output json >$stack_events_json
+    # Check whether there are any failed events
+    cat $stack_events_json | jq '.StackEvents | .[] | select ( .ResourceStatus == "CREATE_FAILED" )'
+
     local stack_delete_start_time=$(date +%s)
     echo "Deleting the stack: $stack_id"
     aws cloudformation delete-stack --stack-name $stack_id


### PR DESCRIPTION
## Purpose
Figure out the reason for any cloudformation stack creation error.

## Goals
Use AWS CLI to get stack events and filter resources with CREATE_FAILED status.