### PR TITLE
Use Oracle JDK for JMeter, Upload distributions to S3 and use a template for markdown file.

### DIFF
--- a/cloudformation/ballerina_perf_test_cfn.yaml
+++ b/cloudformation/ballerina_perf_test_cfn.yaml
@@ -32,13 +32,13 @@ Description: >-
 Mappings:
   AWSRegion2AMI:
     us-east-1:
-      AMI: ami-0ac019f4fcb7cb7e6
+      AMI: ami-0977029b5b13f3d08
     us-east-2:
-      AMI: ami-0f65671a86f061fcd
+      AMI: ami-05f39e7b7f153bc6a
     us-west-1:
-      AMI: ami-063aa838bd7631e0b
+      AMI: ami-03d5270fcb641f79b
     us-west-2:
-      AMI: ami-0bbe6b35405ecebdb
+      AMI: ami-0f47ef92b4218ec09
 #############################
 # User inputs
 #############################
@@ -60,11 +60,21 @@ Parameters:
   PerformanceBallerinaDistributionName:
     Description: The name of the 'Performance Ballerina Distribution' package in S3 Bucket.
     Type: String
-  BallerinaInstallerURL:
-    Description: The URL of the Ballerina Debian Installer
+  JMeterDistributionName:
+    Description: The name of the 'Apache JMeter distribution' in S3 Bucket.
     Type: String
-    ConstraintDescription: must be a valid URL to a deb package
-    AllowedPattern: ^https?:\/\/.*\.deb$
+    ConstraintDescription: must be a valid tgz package
+    AllowedPattern: ^.*\.tgz$
+  BallerinaInstallerName:
+    Description: The name of the 'Ballerina Debian Installer' in S3 Bucket.
+    Type: String
+    ConstraintDescription: must be a valid deb package
+    AllowedPattern: ^.*\.deb$
+  OracleJDKDistributionName:
+    Description: The name of the 'Oracle JDK Distribution' in S3 Bucket.
+    Type: String
+    ConstraintDescription: must be a valid Oracle JDK
+    AllowedPattern: ^jdk-8u[0-9]+-linux-x64.tar.gz$
   JMeterClientInstanceType:
     Description: JMeter Client EC2 instance type
     Type: String
@@ -362,6 +372,32 @@ Resources:
               owner: ubuntu
               group: ubuntu
               authentication: "S3AccessCreds"
+            /home/ubuntu/apache-jmeter.tgz:
+              source: !Join
+                - ''
+                - - 'https://s3.'
+                  - !Ref BucketRegion
+                  - '.amazonaws.com/'
+                  - !Ref BucketName
+                  - /
+                  - !Ref JMeterDistributionName
+              mode: '000664'
+              owner: ubuntu
+              group: ubuntu
+              authentication: "S3AccessCreds"
+            /home/ubuntu/jdk-8-linux-x64.tar.gz:
+              source: !Join
+                - ''
+                - - 'https://s3.'
+                  - !Ref BucketRegion
+                  - '.amazonaws.com/'
+                  - !Ref BucketName
+                  - /
+                  - !Ref OracleJDKDistributionName
+              mode: '000664'
+              owner: ubuntu
+              group: ubuntu
+              authentication: "S3AccessCreds"
           commands:
             01_create_state_directory:
               command: mkdir -p /var/awslogs/state
@@ -421,6 +457,8 @@ Resources:
           # Must run setup script in User Data (Commands executed within cfn-init do not show the progress in logs)
           /home/ubuntu/setup/setup-jmeter-client-ballerina.sh -g -k /home/ubuntu/private_key.pem \
             -i /home/ubuntu \
+            -d /home/ubuntu/jdk-8-linux-x64.tar.gz \
+            -f /home/ubuntu/apache-jmeter.tgz \
             -c /home/ubuntu \
             -a jmeter1 -n ${JMeterServer1Instance.PrivateIp} \
             -a jmeter2 -n ${JMeterServer2Instance.PrivateIp} \
@@ -504,6 +542,32 @@ Resources:
               owner: ubuntu
               group: ubuntu
               authentication: "S3AccessCreds"
+            /home/ubuntu/apache-jmeter.tgz:
+              source: !Join
+                - ''
+                - - 'https://s3.'
+                  - !Ref BucketRegion
+                  - '.amazonaws.com/'
+                  - !Ref BucketName
+                  - /
+                  - !Ref JMeterDistributionName
+              mode: '000664'
+              owner: ubuntu
+              group: ubuntu
+              authentication: "S3AccessCreds"
+            /home/ubuntu/jdk-8-linux-x64.tar.gz:
+              source: !Join
+                - ''
+                - - 'https://s3.'
+                  - !Ref BucketRegion
+                  - '.amazonaws.com/'
+                  - !Ref BucketName
+                  - /
+                  - !Ref OracleJDKDistributionName
+              mode: '000664'
+              owner: ubuntu
+              group: ubuntu
+              authentication: "S3AccessCreds"
           commands:
             01_create_state_directory:
               command: mkdir -p /var/awslogs/state
@@ -561,7 +625,7 @@ Resources:
           # Initialize
           /usr/local/bin/cfn-init -v --stack ${AWS::StackId} --resource JMeterServer1Instance --region ${AWS::Region}
           # Run setup
-          /home/ubuntu/setup/setup-jmeter-ballerina.sh -g -i /home/ubuntu
+          /home/ubuntu/setup/setup-jmeter-ballerina.sh -g -i /home/ubuntu -d /home/ubuntu/jdk-8-linux-x64.tar.gz -f /home/ubuntu/apache-jmeter.tgz
           # Signal
           /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource JMeterServer1Instance --region ${AWS::Region}
     CreationPolicy:
@@ -640,6 +704,32 @@ Resources:
               owner: ubuntu
               group: ubuntu
               authentication: "S3AccessCreds"
+            /home/ubuntu/apache-jmeter.tgz:
+              source: !Join
+                - ''
+                - - 'https://s3.'
+                  - !Ref BucketRegion
+                  - '.amazonaws.com/'
+                  - !Ref BucketName
+                  - /
+                  - !Ref JMeterDistributionName
+              mode: '000664'
+              owner: ubuntu
+              group: ubuntu
+              authentication: "S3AccessCreds"
+            /home/ubuntu/jdk-8-linux-x64.tar.gz:
+              source: !Join
+                - ''
+                - - 'https://s3.'
+                  - !Ref BucketRegion
+                  - '.amazonaws.com/'
+                  - !Ref BucketName
+                  - /
+                  - !Ref OracleJDKDistributionName
+              mode: '000664'
+              owner: ubuntu
+              group: ubuntu
+              authentication: "S3AccessCreds"
           commands:
             01_create_state_directory:
               command: mkdir -p /var/awslogs/state
@@ -697,7 +787,7 @@ Resources:
           # Initialize
           /usr/local/bin/cfn-init -v --stack ${AWS::StackId} --resource JMeterServer2Instance --region ${AWS::Region}
           # Run setup
-          /home/ubuntu/setup/setup-jmeter-ballerina.sh -g -i /home/ubuntu
+          /home/ubuntu/setup/setup-jmeter-ballerina.sh -g -i /home/ubuntu -d /home/ubuntu/jdk-8-linux-x64.tar.gz -f /home/ubuntu/apache-jmeter.tgz
           # Signal
           /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource JMeterServer2Instance --region ${AWS::Region}
     CreationPolicy:
@@ -776,6 +866,19 @@ Resources:
               owner: ubuntu
               group: ubuntu
               authentication: "S3AccessCreds"
+            /home/ubuntu/ballerina_installer.deb:
+              source: !Join
+                - ''
+                - - 'https://s3.'
+                  - !Ref BucketRegion
+                  - '.amazonaws.com/'
+                  - !Ref BucketName
+                  - /
+                  - !Ref BallerinaInstallerName
+              mode: '000775'
+              owner: ubuntu
+              group: ubuntu
+              authentication: "S3AccessCreds"
           commands:
             01_create_state_directory:
               command: mkdir -p /var/awslogs/state
@@ -833,7 +936,7 @@ Resources:
           # Initialize
           /usr/local/bin/cfn-init -v --stack ${AWS::StackId} --resource BallerinaInstance --region ${AWS::Region}
           # Run setup
-          /home/ubuntu/setup/setup-ballerina.sh -g -u ${BallerinaInstallerURL} -n ${BackendInstance.PrivateIp}
+          /home/ubuntu/setup/setup-ballerina.sh -g -d /home/ubuntu/ballerina_installer.deb -n ${BackendInstance.PrivateIp}
           # Signal
           /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource BallerinaInstance --region ${AWS::Region}
     CreationPolicy:
@@ -912,6 +1015,19 @@ Resources:
               owner: ubuntu
               group: ubuntu
               authentication: "S3AccessCreds"
+            /home/ubuntu/jdk-8-linux-x64.tar.gz:
+              source: !Join
+                - ''
+                - - 'https://s3.'
+                  - !Ref BucketRegion
+                  - '.amazonaws.com/'
+                  - !Ref BucketName
+                  - /
+                  - !Ref OracleJDKDistributionName
+              mode: '000664'
+              owner: ubuntu
+              group: ubuntu
+              authentication: "S3AccessCreds"
           commands:
             01_create_state_directory:
               command: mkdir -p /var/awslogs/state
@@ -969,7 +1085,7 @@ Resources:
           # Initialize
           /usr/local/bin/cfn-init -v --stack ${AWS::StackId} --resource BackendInstance --region ${AWS::Region}
           # Run setup
-          /home/ubuntu/setup/setup-netty.sh -g
+          /home/ubuntu/setup/setup-netty.sh -g -d /home/ubuntu/jdk-8-linux-x64.tar.gz
           # Signal
           /usr/local/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource BackendInstance --region ${AWS::Region}
     CreationPolicy:
@@ -979,3 +1095,6 @@ Outputs:
   JMeterClientPublicIP:
     Description: JMeter Client Public IP
     Value: !GetAtt JMeterClientInstance.PublicIp
+  LogGroupName:
+    Description: Log Group Name
+    Value: !Ref CloudFormationLogs

--- a/cloudformation/run-performance-tests.sh
+++ b/cloudformation/run-performance-tests.sh
@@ -457,5 +457,11 @@ unzip -q results.zip
 wget -q http://sourceforge.net/projects/gcviewer/files/gcviewer-1.35.jar/download -O gcviewer.jar
 ./jmeter/create-summary-csv.sh -d results -n Ballerina -p ballerina -j 2 -g gcviewer.jar
 
-echo "Converting summary results to markdown format..."
-./jmeter/csv-to-markdown-converter.py summary.csv summary.md
+echo "Create summary results markdown file"
+# Use following to get all column names:
+# while IFS= read -r line; do echo -ne " \"$line\""; done < <(./jmeter/create-summary-csv.sh -n "Ballerina" -j 2 -i -x)
+
+./jmeter/create-summary-markdown.py --json-files cf-test-metadata.json results/test-metadata.json --column-names \
+    "Scenario Name" "Concurrent Users" "Message Size (Bytes)" "Back-end Service Delay (ms)" "Error %" "Throughput (Requests/sec)" \
+    "Average Response Time (ms)" "Standard Deviation of Response Time (ms)" "99th Percentile of Response Time (ms)" \
+    "Ballerina GC Throughput (%)" "Average of Ballerina Memory Footprint After Full GC (M)"

--- a/distribution/bin.xml
+++ b/distribution/bin.xml
@@ -29,11 +29,6 @@
             <useStrictFiltering>true</useStrictFiltering>
             <useProjectArtifact>false</useProjectArtifact>
             <unpack>true</unpack>
-            <unpackOptions>
-                <excludes>
-                    <exclude>java/**</exclude>
-                </excludes>
-            </unpackOptions>
             <outputDirectory>.</outputDirectory>
         </dependencySet>
     </dependencySets>

--- a/distribution/scripts/jmeter/templates/summary.md
+++ b/distribution/scripts/jmeter/templates/summary.md
@@ -1,0 +1,61 @@
+# Ballerina Performance Test Results
+
+During each release, we execute various automated performance test scenarios and publish the results.
+
+| Test Scenarios | Description |
+| --- | --- |
+{%- for test_scenario in parameters.test_scenarios %}
+| {{test_scenario.display_name}} | {{test_scenario.description}} |
+{%- endfor %}
+
+Our test client is [Apache JMeter](https://jmeter.apache.org/index.html). We test each scenario for a fixed duration of
+time. We split the test results into warmup and measurement parts and use the measurement part to compute the
+performance metrics.
+
+A majority of test scenarios use a [Netty](https://netty.io/) based back-end service which echoes back any request
+posted to it after a specified period of time.
+
+We run the performance tests under different numbers of concurrent users, message sizes (payloads) and back-end service
+delays.
+
+The main performance metrics:
+
+1. **Throughput**: The number of requests that the Ballerina service processes during a specific time interval (e.g. per second).
+2. **Response Time**: The end-to-end latency for an operation of invoking a Ballerina service. The complete distribution of response times was recorded.
+
+In addition to the above metrics, we measure the load average and several memory-related metrics.
+
+The following are the test parameters.
+
+| Test Parameter | Description | Values |
+| --- | --- | --- |
+| Scenario Name | The name of the test scenario. | Refer to the above table. |
+| Heap Size | The amount of memory allocated to the application | {{ parameters.heap_sizes|join(', ') }} |
+| Concurrent Users | The number of users accessing the application at the same time. | {{ parameters.concurrent_users|join(', ') }} |
+| Message Size (Bytes) | The request payload size in Bytes. | {{ parameters.message_sizes|join(', ') }} |
+| Back-end Delay (ms) | The delay added by the back-end service. | {{ parameters.backend_sleep_times|join(', ') }} |
+
+The duration of each test is **{{ parameters.test_duration }} seconds**. The warm-up period is **{{ parameters.warmup_time }} seconds**.
+The measurement results are collected after the warm-up period.
+
+A [**{{ parameters.ballerina_ec2_instance_type }}** Amazon EC2 instance](https://aws.amazon.com/ec2/instance-types/) was used to install Ballerina.
+
+The following are the measurements collected from each performance test conducted for a given combination of
+test parameters.
+
+| Measurement | Description |
+| --- | --- |
+| Error % | Percentage of requests with errors |
+| Average Response Time (ms) | The average response time of a set of results |
+| Standard Deviation of Response Time (ms) | The “Standard Deviation” of the response time. |
+| 99th Percentile of Response Time (ms) | 99% of the requests took no more than this time. The remaining samples took at least as long as this |
+| Throughput (Requests/sec) | The throughput measured in requests per second. |
+| Average Memory Footprint After Full GC (M) | The average memory consumed by the application after a full garbage collection event. |
+
+The following is the summary of performance test results collected for the measurement period.
+
+| {% for column_name in column_names %} {{ column_name }} |{%- endfor %}
+| {%- for column_name in column_names %}---{% if not loop.first %}:{% endif%}|{%- endfor %}
+{%- for row in rows %}
+| {% for column_name in column_names %} {{ row[column_name] }} |{% endfor %}
+{%- endfor %}

--- a/distribution/scripts/setup/setup-ballerina.sh
+++ b/distribution/scripts/setup/setup-ballerina.sh
@@ -28,24 +28,24 @@ fi
 
 export script_name="$0"
 export script_dir=$(dirname "$0")
-export download_url=""
+export ballerina_installer=""
 export netty_host=""
 
 function usageCommand() {
-    echo "-u <download_url> -n <netty_host>"
+    echo "-d <ballerina_installer> -n <netty_host>"
 }
 export -f usageCommand
 
 function usageHelp() {
-    echo "-u: The download url of ballerina installer."
+    echo "-d: Ballerina Installer Debian Package."
     echo "-n: The hostname of Netty Service."
 }
 export -f usageHelp
 
-while getopts "gp:w:o:hu:n:" opt; do
+while getopts "gp:w:o:hd:n:" opt; do
     case "${opt}" in
-    u)
-        download_url=${OPTARG}
+    d)
+        ballerina_installer=${OPTARG}
         ;;
     n)
         netty_host=${OPTARG}
@@ -59,8 +59,8 @@ done
 shift "$((OPTIND - 1))"
 
 function validate() {
-    if [[ -z $download_url ]]; then
-        echo "Please provide the download url for the Ballerina Installer."
+    if [[ ! -f $ballerina_installer ]]; then
+        echo "Please provide Ballerina Installer."
         exit 1
     fi
 
@@ -72,11 +72,7 @@ function validate() {
 export -f validate
 
 function setup() {
-    if [[ ! -f ballerina_installer.deb ]]; then
-        echo "Downloading Ballerina distribution"
-        wget -q $download_url -O ballerina_installer.deb
-    fi
-    dpkg -i ballerina_installer.deb
+    dpkg -i $ballerina_installer
     echo "$netty_host netty" >>/etc/hosts
 
     # Build Ballerina Files

--- a/distribution/scripts/setup/setup-jmeter-ballerina.sh
+++ b/distribution/scripts/setup/setup-jmeter-ballerina.sh
@@ -33,5 +33,5 @@ alpnboot_dir="/opt/alpnboot"
 mkdir -p $alpnboot_dir
 
 $script_dir/setup-jmeter.sh "$@" -j bzm-http2 -j websocket-samplers \
-    -w http://search.maven.org/remotecontent?filepath=org/mortbay/jetty/alpn/alpn-boot/8.1.12.v20180117/alpn-boot-8.1.12.v20180117.jar \
+    -w http://search.maven.org/remotecontent?filepath=org/mortbay/jetty/alpn/alpn-boot/8.1.13.v20181017/alpn-boot-8.1.13.v20181017.jar \
     -o $alpnboot_dir/alpnboot.jar

--- a/distribution/scripts/setup/setup-jmeter-client-ballerina.sh
+++ b/distribution/scripts/setup/setup-jmeter-client-ballerina.sh
@@ -33,5 +33,5 @@ alpnboot_dir="/opt/alpnboot"
 mkdir -p $alpnboot_dir
 
 $script_dir/setup-jmeter-client.sh "$@" -j bzm-http2 -j websocket-samplers \
-    -w http://search.maven.org/remotecontent?filepath=org/mortbay/jetty/alpn/alpn-boot/8.1.12.v20180117/alpn-boot-8.1.12.v20180117.jar \
+    -w http://search.maven.org/remotecontent?filepath=org/mortbay/jetty/alpn/alpn-boot/8.1.13.v20181017/alpn-boot-8.1.13.v20181017.jar \
     -o $alpnboot_dir/alpnboot.jar


### PR DESCRIPTION
## Purpose
Use Oracle JDK for JMeter, Upload distributions to S3 and use a template for markdown file.

## Goals
* Use Oracle JDK for JMeter and upload distributions to S3
* Upload Ballerina, Oracle JDK and JMeter distributions to S3
* Create summary.md from a template 